### PR TITLE
Use Host in Query Parameter if allowed

### DIFF
--- a/cmd/rdpgw/api/web.go
+++ b/cmd/rdpgw/api/web.go
@@ -157,6 +157,17 @@ func (c *Config) HandleDownload(w http.ResponseWriter, r *http.Request) {
 	rand.Seed(time.Now().Unix())
 	host := c.Hosts[rand.Intn(len(c.Hosts))]
 	host = strings.Replace(host, "{{ preferred_username }}", userName, 1)
+	
+	
+	//Change Host to value of host query Parameter if host query string is in Config Hosts
+	paraHost, hasParaHost := r.URL.Query()["host"]
+	if hasParaHost {
+        for _,a := range c.Hosts {
+            if a==paraHost[0] {
+                host=paraHost[0]
+            }
+        }
+    }
 
 	// split the username into user and domain
 	var user = userName

--- a/cmd/rdpgw/api/web.go
+++ b/cmd/rdpgw/api/web.go
@@ -160,11 +160,11 @@ func (c *Config) HandleDownload(w http.ResponseWriter, r *http.Request) {
 	
 	
 	//Change Host to value of host query Parameter if host query string is in Config Hosts
-	paraHost, hasParaHost := r.URL.Query()["host"]
-	if hasParaHost {
-        for _,a := range c.Hosts {
-            if a==paraHost[0] {
-                host=paraHost[0]
+	parameterHost, hasParameterHost := r.URL.Query()["host"]
+	if hasParameterHost {
+        for _,configHost := range c.Hosts {
+            if configHost==parameterHost[0] {
+                host=parameterHost[0]
             }
         }
     }


### PR DESCRIPTION
This Commit allows Admins to add a Host to the connect URL (https://example.com?host=127.0.0.1:3389).
This way Admins can link to Remote Desktop Sessions on a specific Host in Links.

Only works, if the host query Parameter is in the Host List in the Config. Otherwise, the Server picks a random Host.