### PR TITLE
Docker not working with latest Keycloak

### DIFF
--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -3,6 +3,9 @@ FROM golang as builder
 
 RUN apt-get update && apt-get install -y libpam-dev
 
+# add user
+RUN adduser --disabled-password --gecos "" --home /opt/rdpgw --uid 1001 rdpgw
+
 # certificate
 RUN mkdir -p /opt/rdpgw && cd /opt/rdpgw && \
     random=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1) && \
@@ -13,9 +16,6 @@ RUN mkdir -p /opt/rdpgw && cd /opt/rdpgw && \
     -subj "/C=US/ST=VA/L=SomeCity/O=MyCompany/OU=MyDivision/CN=rdpgw" && \
     openssl x509 -req -days 365 -in server.csr -signkey key.pem -out server.pem
 
-# add user
-RUN adduser --disabled-password --gecos "" --home /opt/rdpgw --uid 1001 rdpgw
-
 # build rdpgw and set rights
 ARG CACHEBUST
 RUN git clone https://github.com/bolkedebruin/rdpgw.git /app && \
@@ -25,20 +25,20 @@ RUN git clone https://github.com/bolkedebruin/rdpgw.git /app && \
     CGO_ENABLED=1 GOOS=linux go build -trimpath -tags '' -ldflags '' -o '/opt/rdpgw/rdpgw-auth' ./cmd/auth && \
     chmod +x /opt/rdpgw/rdpgw && \
     chmod +x /opt/rdpgw/rdpgw-auth && \
-    chmod u+s /opt/rdpgw/rdpgw-auth && \
-    chown -R 1001 /opt/rdpgw
+    chmod u+s /opt/rdpgw/rdpgw-auth
 
 FROM scratch 
 
 # make tempdir in case filestore is used
 ADD tmp.tar /
 
-COPY --from=builder /opt/rdpgw /opt/rdpgw
-COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder /etc/ssl/certs /etc/ssl/certs
-
-COPY rdpgw.yaml /opt/rdpgw/rdpgw.yaml
-
 USER 1001
+
+COPY --chown=1001 --from=builder /opt/rdpgw /opt/rdpgw
+COPY --chown=1001 --from=builder /etc/passwd /etc/passwd
+COPY --chown=1001 --from=builder /etc/ssl/certs /etc/ssl/certs
+
+COPY --chown=1001 rdpgw.yaml /opt/rdpgw/rdpgw.yaml
+
 WORKDIR /opt/rdpgw
 ENTRYPOINT ["/opt/rdpgw/rdpgw"]

--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -11,18 +11,17 @@ services:
       image: quay.io/keycloak/keycloak:latest
       hostname: keycloak
       volumes:
-        - ${PWD}/realm-export.json:/export/realm-export.json
+        - ${PWD}/realm-export.json:/opt/keycloak/data/import/realm-export.json
       environment:
         KEYCLOAK_USER: admin
         KEYCLOAK_PASSWORD: admin
-        KEYCLOAK_IMPORT: /export/realm-export.json
         KEYCLOAK_ADMIN: admin
         KEYCLOAK_ADMIN_PASSWORD: admin
       ports:
         - 8080:8080
       restart: on-failure
       command:
-        - start-dev
+        - start-dev --import-realm --http-relative-path=/aut
       healthcheck:
         test: ["CMD", "curl", "-f", "http://localhost:8080/auth"]
         interval: 30s

--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -21,7 +21,7 @@ services:
         - 8080:8080
       restart: on-failure
       command:
-        - start-dev --import-realm --http-relative-path=/aut
+        - start-dev --import-realm --http-relative-path=/auth
       healthcheck:
         test: ["CMD", "curl", "-f", "http://localhost:8080/auth"]
         interval: 30s


### PR DESCRIPTION
- Keycloak was not importing realm from json. Envvar KEYCLOAK_IMPORT is not working. See #https://github.com/keycloak/keycloak/issues/10216
- rdpgw tries to access Keycloak at http://keycloak:8080**/auth**, however it is available at http://keycloak:8080**/** per default. used `--http-relative-path=/auth` to set the path to /auth to make Keycloak available
- adduser after home path is already present will cause warning. Move up
- chown was not working in RUN. access to generated key.pem failed for rdpgw. use [proposed ](https://stackoverflow.com/questions/28879364/docker-copy-and-change-owner) "--chown" in COPY