### PR TITLE
Can omit username from rendered RDP

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Client:
   # If true puts splits "user@domain.com" into the user and domain component so that
   # domain gets set in the rdp file and the domain name is stripped from the username
   SplitUserDomain: false
+  # If true, removes "username" (and "domain" if SplitUserDomain is true) from RDP file.
+  # NoUsername: true
 Security:
   # a random string of 32 characters to secure cookies on the client
   # make sure to share this amongst different pods

--- a/cmd/rdpgw/config/configuration.go
+++ b/cmd/rdpgw/config/configuration.go
@@ -93,6 +93,7 @@ type ClientConfig struct {
 	// kept for backwards compatibility
 	UsernameTemplate string `koanf:"usernametemplate"`
 	SplitUserDomain  bool   `koanf:"splituserdomain"`
+	NoUsername string `koanf:"nousername"`
 }
 
 func ToCamel(s string) string {

--- a/cmd/rdpgw/main.go
+++ b/cmd/rdpgw/main.go
@@ -110,6 +110,7 @@ func main() {
 		RdpOpts: web.RdpOpts{
 			UsernameTemplate: conf.Client.UsernameTemplate,
 			SplitUserDomain:  conf.Client.SplitUserDomain,
+			NoUsername: conf.Client.NoUsername,
 		},
 		GatewayAddress: url,
 		TemplateFile:   conf.Client.Defaults,

--- a/cmd/rdpgw/web/web.go
+++ b/cmd/rdpgw/web/web.go
@@ -37,6 +37,7 @@ type Config struct {
 type RdpOpts struct {
 	UsernameTemplate string
 	SplitUserDomain  bool
+	NoUsername bool
 }
 
 type Handler struct {
@@ -210,9 +211,11 @@ func (h *Handler) HandleDownload(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	d.Settings.Username = render
-	if domain != "" {
-		d.Settings.Domain = domain
+	if !NoUsername {
+		d.Settings.Username = render
+		if domain != "" {
+			d.Settings.Domain = domain
+		}
 	}
 	d.Settings.FullAddress = host
 	d.Settings.GatewayHostname = h.gatewayAddress.Host


### PR DESCRIPTION
Following PR #58 too. That patch had one extra ability that your main branch doesn't have yet: omitting the `username` field.

Without this field, the RDP window opens and asks the password for the last authenticated user on the device, or to switch to another user, within the joined domain. Well it looks exactly like the authentication screen in front of the actual computer.

Random image to exemplify:
![example](https://duo.com/assets/img/documentation/rdp/login_2x.png)

The current behavior, with this field, is to always ask for username and password, with undefined domain.

Random image to exemplify:
![example](https://www.niallbrady.com/wp-content/uploads/2017/08/azuread-creds-1024x775.png)

Note that I'm connecting to AAD-joined devices from personal (non-AAD-joined) device. FTR, the username is indeed `AzureAD\email@domain` like shown on the second image. The corresponding config is

    UsernameTemplate: '.\AzureAD\{{ username }}'
 
(no idea why `.\` is required) and the following defaults are needed

    authentication level:i:2
    enablecredsspsupport:i:0

as documented on many websites. I think these info are valuable and should appear on the README.