### PR TITLE
Adjust Basic Auth Timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Server:
  # The socket to connect to if using local auth. Ensure rdpgw auth is configured to
  # use the same socket.
  AuthSocket: /tmp/rdpgw-auth.sock
+ # Basic auth timeout (in seconds). Useful if you're planning on waiting for MFA
+ BasicAuthTimeout: 5
  # The default option 'auto' uses a certificate file if provided and found otherwise
  # it uses letsencrypt to obtain a certificate, the latter requires that the host is reachable
  # from letsencrypt servers. If TLS termination happens somewhere else (e.g. a load balancer)

--- a/cmd/rdpgw/config/configuration.go
+++ b/cmd/rdpgw/config/configuration.go
@@ -51,6 +51,7 @@ type ServerConfig struct {
 	Tls                  string   `koanf:"tls"`
 	Authentication       []string `koanf:"authentication"`
 	AuthSocket           string   `koanf:"authsocket"`
+	BasicAuthTimeout     int      `koanf:"basicauthtimeout"`
 }
 
 type KerberosConfig struct {
@@ -143,6 +144,7 @@ func Load(configFile string) Configuration {
 		"Server.HostSelection":       "roundrobin",
 		"Server.Authentication":      "openid",
 		"Server.AuthSocket":          "/tmp/rdpgw-auth.sock",
+		"Server.BasicAuthTimeout":    5,
 		"Client.NetworkAutoDetect":   1,
 		"Client.BandwidthAutoDetect": 1,
 		"Security.VerifyClientIp":    true,

--- a/cmd/rdpgw/main.go
+++ b/cmd/rdpgw/main.go
@@ -232,7 +232,7 @@ func main() {
 	// basic auth
 	if conf.Server.BasicAuthEnabled() {
 		log.Printf("enabling basic authentication")
-		q := web.BasicAuthHandler{SocketAddress: conf.Server.AuthSocket}
+		q := web.BasicAuthHandler{SocketAddress: conf.Server.AuthSocket, Timeout: conf.Server.BasicAuthTimeout}
 		rdp.NewRoute().HeadersRegexp("Authorization", "Basic").HandlerFunc(q.BasicAuth(gw.HandleGatewayProtocol))
 		auth.Register(`Basic realm="restricted", charset="UTF-8"`)
 	}

--- a/cmd/rdpgw/web/basic.go
+++ b/cmd/rdpgw/web/basic.go
@@ -18,6 +18,7 @@ const (
 
 type BasicAuthHandler struct {
 	SocketAddress string
+	Timeout       int
 }
 
 func (h *BasicAuthHandler) BasicAuth(next http.HandlerFunc) http.HandlerFunc {
@@ -38,7 +39,7 @@ func (h *BasicAuthHandler) BasicAuth(next http.HandlerFunc) http.HandlerFunc {
 			defer conn.Close()
 
 			c := auth.NewAuthenticateClient(conn)
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(h.Timeout))
 			defer cancel()
 
 			req := &auth.UserPass{Username: username, Password: password}


### PR DESCRIPTION
We are using "local" auth in combination with pam_radius to authenticate via DUO proxy (i.e. RADIUS server with MFA) and found the BasicAuth timeout was statically set to 5 seconds. This does not leave users enough time to respond to MFA requests before the context deadline drops the connection.

This removes the static 5 seconds and adds a configuration setting for "BasicAuthTimeout" with a default of 5 seconds, but is configurable in cases such as these where longer timeouts are prefereable.