### PR TITLE
Updates docker compose keycloak command

### DIFF
--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -21,7 +21,9 @@ services:
         - 8080:8080
       restart: on-failure
       command:
-        - start-dev --import-realm --http-relative-path=/auth
+        - start-dev
+        - --import-realm
+        - --http-relative-path=/auth
       healthcheck:
         test: ["CMD", "curl", "-f", "http://localhost:8080/auth"]
         interval: 30s


### PR DESCRIPTION
This splits the command used to start keycloak in the dev docker compose configuration into a list.

This should fix #89 