### PR TITLE
Disable UserTokenSigningKey randomization

### DIFF
--- a/cmd/rdpgw/config/configuration.go
+++ b/cmd/rdpgw/config/configuration.go
@@ -200,11 +200,6 @@ func Load(configFile string) Configuration {
 			Conf.Security.UserTokenEncryptionKey, _ = security.GenerateRandomString(32)
 			log.Printf("No valid `security.usertokenencryptionkey` specified (empty or not 32 characters). Setting to random")
 		}
-
-		if len(Conf.Security.UserTokenSigningKey) != 32 {
-			Conf.Security.UserTokenSigningKey, _ = security.GenerateRandomString(32)
-			log.Printf("No valid `security.usertokensigningkey` specified (empty or not 32 characters). Setting to random")
-		}
 	}
 
 	if len(Conf.Server.SessionKey) != 32 {


### PR DESCRIPTION
To make the usage of user tokens possible [one needs to make *UserTokenSigningKey* blank](https://github.com/bolkedebruin/rdpgw/issues/106). This patch disables replacement of an empty *UserTokenSigningKey* with a random value.
