### PR TITLE
Allow signing downloaded RDP file

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,12 @@ Client:
   SplitUserDomain: false
   # If true, removes "username" (and "domain" if SplitUserDomain is true) from RDP file.
   # NoUsername: true
+  # If both SigningCert and SigningKey are set the downloaded RDP file will be signed
+  # so the client can authenticate the validity of the RDP file and reduce warnings from
+  # the client if the CA that issued the certificate is trusted. Both should be PEM encoded
+  # and the key must be an unencrypted RSA private key.
+  # SigningCert: /path/to/signing.crt
+  # SigningKey: /path/to/signing.key
 Security:
   # a random string of 32 characters to secure cookies on the client
   # make sure to share this amongst different pods

--- a/cmd/rdpgw/config/configuration.go
+++ b/cmd/rdpgw/config/configuration.go
@@ -1,15 +1,16 @@
 package config
 
 import (
+	"log"
+	"os"
+	"strings"
+
 	"github.com/bolkedebruin/rdpgw/cmd/rdpgw/security"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/confmap"
 	"github.com/knadh/koanf/providers/env"
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/v2"
-	"log"
-	"os"
-	"strings"
 )
 
 const (
@@ -96,6 +97,8 @@ type ClientConfig struct {
 	UsernameTemplate string `koanf:"usernametemplate"`
 	SplitUserDomain  bool   `koanf:"splituserdomain"`
 	NoUsername       bool   `koanf:"nousername"`
+	SigningCert      string `koanf:"signingcert"`
+	SigningKey       string `koanf:"signingkey"`
 }
 
 func ToCamel(s string) string {
@@ -219,10 +222,10 @@ func Load(configFile string) Configuration {
 	if Conf.Server.BasicAuthEnabled() && Conf.Server.Tls == "disable" {
 		log.Fatalf("basicauth=local and tls=disable are mutually exclusive")
 	}
-        
+
 	if Conf.Server.NtlmEnabled() && Conf.Server.KerberosEnabled() {
 		log.Fatalf("ntlm and kerberos authentication are not stackable")
-        }
+	}
 
 	if !Conf.Caps.TokenAuth && Conf.Server.OpenIDEnabled() {
 		log.Fatalf("openid is configured but tokenauth disabled")
@@ -238,7 +241,6 @@ func Load(configFile string) Configuration {
 	}
 
 	return Conf
-
 }
 
 func (s *ServerConfig) OpenIDEnabled() bool {

--- a/cmd/rdpgw/protocol/gateway.go
+++ b/cmd/rdpgw/protocol/gateway.go
@@ -3,17 +3,18 @@ package protocol
 import (
 	"context"
 	"errors"
-	"github.com/bolkedebruin/rdpgw/cmd/rdpgw/identity"
-	"github.com/bolkedebruin/rdpgw/cmd/rdpgw/transport"
-	"github.com/google/uuid"
-	"github.com/gorilla/websocket"
-	"github.com/patrickmn/go-cache"
 	"log"
 	"net"
 	"net/http"
 	"reflect"
 	"syscall"
 	"time"
+
+	"github.com/bolkedebruin/rdpgw/cmd/rdpgw/identity"
+	"github.com/bolkedebruin/rdpgw/cmd/rdpgw/transport"
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+	"github.com/patrickmn/go-cache"
 )
 
 const (
@@ -140,7 +141,7 @@ func (g *Gateway) setSendReceiveBuffers(conn net.Conn) error {
 	if !ptrSysFd.IsValid() {
 		return errors.New("cannot find Sysfd field")
 	}
-	fd := int(ptrSysFd.Int())
+	fd := int64ToFd(ptrSysFd.Int())
 
 	if g.ReceiveBuf > 0 {
 		err := syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_RCVBUF, g.ReceiveBuf)

--- a/cmd/rdpgw/protocol/gateway_linux.go
+++ b/cmd/rdpgw/protocol/gateway_linux.go
@@ -1,0 +1,6 @@
+package protocol
+
+// the fd arg to syscall.SetsockoptInt on Linix is of type int
+func int64ToFd(n int64) int {
+	return int(n)
+}

--- a/cmd/rdpgw/protocol/gateway_others.go
+++ b/cmd/rdpgw/protocol/gateway_others.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package protocol
 
 // the fd arg to syscall.SetsockoptInt on Linix is of type int

--- a/cmd/rdpgw/protocol/gateway_windows.go
+++ b/cmd/rdpgw/protocol/gateway_windows.go
@@ -1,0 +1,10 @@
+package protocol
+
+import (
+	"syscall"
+)
+
+// the fd arg to syscall.SetsockoptInt on Windows is of type syscall.Handle
+func int64ToFd(n int64) syscall.Handle {
+	return syscall.Handle(n)
+}

--- a/cmd/rdpgw/web/oidc.go
+++ b/cmd/rdpgw/web/oidc.go
@@ -4,12 +4,13 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"net/http"
+	"time"
+
 	"github.com/bolkedebruin/rdpgw/cmd/rdpgw/identity"
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/patrickmn/go-cache"
 	"golang.org/x/oauth2"
-	"net/http"
-	"time"
 )
 
 const (
@@ -91,7 +92,7 @@ func (h *OIDC) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	id.SetAuthTime(time.Now())
 	id.SetAttribute(identity.AttrAccessToken, oauth2Token.AccessToken)
 
-	if err = SaveSessionIdentity(r, w, id); err != nil {
+	if err := SaveSessionIdentity(r, w, id); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 

--- a/cmd/rdpgw/web/web.go
+++ b/cmd/rdpgw/web/web.go
@@ -79,7 +79,7 @@ func (c *Config) NewHandler() *Handler {
 
 	// set up RDP signer if config values are set
 	if c.RdpSigningCert != "" && c.RdpSigningKey != "" {
-		signer, err := rdpsign.NewSigner(c.RdpSigningCert, c.RdpSigningKey)
+		signer, err := rdpsign.New(c.RdpSigningCert, c.RdpSigningKey)
 		if err != nil {
 			log.Fatal("Could not set up RDP signer", err)
 		}
@@ -178,7 +178,7 @@ func (h *Handler) HandleDownload(w http.ResponseWriter, r *http.Request) {
 
 	render := user
 	if opts.UsernameTemplate != "" {
-		render = fmt.Sprintf(h.rdpOpts.UsernameTemplate)
+		render = fmt.Sprint(h.rdpOpts.UsernameTemplate)
 		render = strings.Replace(render, "{{ username }}", user, 1)
 		if h.rdpOpts.UsernameTemplate == render {
 			log.Printf("Invalid username template. %s == %s", h.rdpOpts.UsernameTemplate, user)
@@ -252,7 +252,7 @@ func (h *Handler) HandleDownload(w http.ResponseWriter, r *http.Request) {
 	rdpContent := d.String()
 
 	// sign rdp content
-	signedContent, err := h.rdpSigner.SignRdp(rdpContent)
+	signedContent, err := h.rdpSigner.Sign(rdpContent)
 	if err != nil {
 		log.Printf("Could not sign RDP file due to %s", err)
 		http.Error(w, errors.New("could not sign RDP file").Error(), http.StatusInternalServerError)

--- a/cmd/rdpgw/web/web.go
+++ b/cmd/rdpgw/web/web.go
@@ -1,13 +1,12 @@
 package web
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/bolkedebruin/rdpgw/cmd/rdpgw/identity"
-	"github.com/bolkedebruin/rdpgw/cmd/rdpgw/rdp"
 	"hash/maphash"
 	"log"
 	rnd "math/rand"
@@ -15,6 +14,10 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/andrewheberle/rdpsign"
+	"github.com/bolkedebruin/rdpgw/cmd/rdpgw/identity"
+	"github.com/bolkedebruin/rdpgw/cmd/rdpgw/rdp"
 )
 
 type TokenGeneratorFunc func(context.Context, string, string) (string, error)
@@ -32,6 +35,8 @@ type Config struct {
 	GatewayAddress     *url.URL
 	RdpOpts            RdpOpts
 	TemplateFile       string
+	RdpSigningCert     string
+	RdpSigningKey      string
 }
 
 type RdpOpts struct {
@@ -51,6 +56,7 @@ type Handler struct {
 	hostSelection      string
 	rdpOpts            RdpOpts
 	rdpDefaults        string
+	rdpSigner          *rdpsign.Signer
 }
 
 func (c *Config) NewHandler() *Handler {
@@ -58,7 +64,7 @@ func (c *Config) NewHandler() *Handler {
 		log.Fatal("Not enough hosts to connect to specified")
 	}
 
-	return &Handler{
+	handler := &Handler{
 		paaTokenGenerator:  c.PAATokenGenerator,
 		enableUserToken:    c.EnableUserToken,
 		userTokenGenerator: c.UserTokenGenerator,
@@ -70,6 +76,18 @@ func (c *Config) NewHandler() *Handler {
 		rdpOpts:            c.RdpOpts,
 		rdpDefaults:        c.TemplateFile,
 	}
+
+	// set up RDP signer if config values are set
+	if c.RdpSigningCert != "" && c.RdpSigningKey != "" {
+		signer, err := rdpsign.NewSigner(c.RdpSigningCert, c.RdpSigningKey)
+		if err != nil {
+			log.Fatal("Could not set up RDP signer", err)
+		}
+
+		handler.rdpSigner = signer
+	}
+
+	return handler
 }
 
 func (h *Handler) selectRandomHost() string {
@@ -223,6 +241,22 @@ func (h *Handler) HandleDownload(w http.ResponseWriter, r *http.Request) {
 	d.Settings.GatewayAccessToken = token
 	d.Settings.GatewayCredentialMethod = 1
 	d.Settings.GatewayUsageMethod = 1
+
+	if h.rdpSigner != nil {
+		// get rdp content
+		rdpContent := d.String()
+
+		signedContent, err := h.rdpSigner.SignRdp(rdpContent)
+		if err != nil {
+			log.Printf("Could not sign RDP file due to %s", err)
+			http.Error(w, errors.New("could not sign RDP file").Error(), http.StatusInternalServerError)
+			return
+		}
+
+		// return signd rdp file
+		http.ServeContent(w, r, fn, time.Now(), bytes.NewReader(signedContent))
+		return
+	}
 
 	http.ServeContent(w, r, fn, time.Now(), strings.NewReader(d.String()))
 }

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
 module github.com/bolkedebruin/rdpgw
 
-go 1.23.0
-
-toolchain go1.24.1
+go 1.24.2
 
 require (
+	github.com/andrewheberle/rdpsign v1.0.0
 	github.com/bolkedebruin/gokrb5/v8 v8.5.0
 	github.com/coreos/go-oidc/v3 v3.9.0
 	github.com/fatih/structs v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bolkedebruin/rdpgw
 go 1.24.2
 
 require (
-	github.com/andrewheberle/rdpsign v1.0.0
+	github.com/andrewheberle/rdpsign v1.1.0
 	github.com/bolkedebruin/gokrb5/v8 v8.5.0
 	github.com/coreos/go-oidc/v3 v3.9.0
 	github.com/fatih/structs v1.1.0
@@ -24,6 +24,7 @@ require (
 	github.com/msteinert/pam/v2 v2.0.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/prometheus/client_golang v1.19.0
+	github.com/spf13/afero v1.14.0
 	github.com/stretchr/testify v1.10.0
 	github.com/thought-machine/go-flags v1.6.3
 	golang.org/x/crypto v0.36.0


### PR DESCRIPTION
This PR adds two new configuration options under the `Client` section of `SigningCert` and `SigningKey`, which when set with the path of a PEM encoded certificate and an unencrypted PEM encoded RSA private key, will cause the RDP file presented to the user to be signed.

This will limit the warnings user get if they trust the CA used to issue the signing certificate.

Unfortunately I do not have tests for this functionality at the moment apart from "it works for me" as I admit the implementation of signing the RDP file was one I did not write myself and I could not find any public documentation on the actual signature format used...except to say the Windows RDP client does accept the signature during my own tests using my forked version _(basic test of signing implemented - see below)_.

The implementation to sign the RDP file is from [gitee.com/cyberkylin/rdpsign](https://gitee.com/cyberkylin/rdpsign) which I just cleaned up a little and turned into a Go module here [andrewheberle/rdpsign](https://github.com/andrewheberle/rdpsign).