### PR TITLE
Ensure autoreconnect setting matches documentation

### DIFF
--- a/cmd/rdpgw/rdp/rdp.go
+++ b/cmd/rdpgw/rdp/rdp.go
@@ -49,7 +49,7 @@ type RdpSettings struct {
 	EnableRdsAasAuth                      bool   `rdp:"enablerdsaadauth" default:"false"`
 	DisableConnectionSharing              bool   `rdp:"disableconnectionsharing" default:"false"`
 	AlternateShell                        string `rdp:"alternate shell"`
-	AutoReconnectionEnabled               bool   `rdp:"autoreconnectionenabled" default:"true"`
+	AutoReconnectionEnabled               bool   `rdp:"autoreconnection enabled" default:"true"`
 	BandwidthAutodetect                   bool   `rdp:"bandwidthautodetect" default:"true"`
 	NetworkAutodetect                     bool   `rdp:"networkautodetect" default:"true"`
 	Compression                           bool   `rdp:"compression" default:"true"`

--- a/cmd/rdpgw/rdp/rdp_test.go
+++ b/cmd/rdpgw/rdp/rdp_test.go
@@ -20,8 +20,8 @@ func TestRdpBuilder(t *testing.T) {
 	if !strings.Contains(s, "gatewayhostname:s:"+GatewayHostName+CRLF) {
 		t.Fatalf("%s does not contain `gatewayhostname:s:%s", s, GatewayHostName)
 	}
-	if strings.Contains(s, "autoreconnectionenabled") {
-		t.Fatalf("autoreconnectionenabled is in %s, but it's default value", s)
+	if strings.Contains(s, "autoreconnection enabled") {
+		t.Fatalf("autoreconnection enabled is in %s, but it's default value", s)
 	}
 	if !strings.Contains(s, "smart sizing:i:1"+CRLF) {
 		t.Fatalf("%s does not contain smart sizing:i:1", s)

--- a/cmd/rdpgw/rdp/rdp_test_file.rdp
+++ b/cmd/rdpgw/rdp/rdp_test_file.rdp
@@ -24,7 +24,7 @@ BitmapPersistenceEnabled:i:0
 AudioRedirectionMode:i:2
 EnablePortRedirection:i:0
 EnableDriveRedirection:i:0
-AutoReconnectEnabled:i:1
+AutoReconnect Enabled:i:1
 EnableSCardRedirection:i:1
 EnablePrinterRedirection:i:0
 BBarEnabled:i:0


### PR DESCRIPTION
The current `rdp.RdpSettings.AutoReconnectionEnabled` is set as `autoreconnectionenabled` however according to the documentation in the following places, this should actually be `autoreconnection enabled`:

- https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/automatic-reconnection-lock-screen?tabs=rdpfile%2Cgpo#client-rdp-properties 
- https://learn.microsoft.com/en-us/azure/virtual-desktop/rdp-properties?context=%2Fwindows-server%2Fcontext%2Fwindows-server-remote-desktop-services#autoreconnection-enabled

This PR resolves this small issue.