### PR TITLE
Add multimon RDP query option

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,9 @@ and RDP file will download to your desktop. This file can be opened by one
 of the remote desktop clients and it will try to connect to the gateway and
 desktop host behind it.
 
+Use `https://your-gateway/connect?multimon=1` to include the `use multimon`
+RDP setting for clients that should span the session across multiple monitors.
+
 ## Integration
 The gateway exposes an endpoint for the verification of user tokens at
 https://yourserver/tokeninfo . The query parameter is 'access_token' so

--- a/cmd/rdpgw/web/web.go
+++ b/cmd/rdpgw/web/web.go
@@ -400,6 +400,57 @@ func (h *Handler) getHost(ctx context.Context, u *url.URL) (string, error) {
 	}
 }
 
+func rdpKey(line string) string {
+	p := strings.IndexByte(line, ':')
+	if p <= 0 {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(line[:p]))
+}
+
+func upsertRdpLines(rdpText string, want []string) string {
+	rdpText = strings.ReplaceAll(rdpText, "\r\n", "\n")
+	rdpText = strings.TrimRight(rdpText, "\n")
+	lines := strings.Split(rdpText, "\n")
+	keyIndex := make(map[string]int, len(lines))
+
+	for i, line := range lines {
+		line = strings.TrimRight(line, "\r")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		key := rdpKey(line)
+		if key == "" {
+			continue
+		}
+		if _, exists := keyIndex[key]; !exists {
+			keyIndex[key] = i
+		}
+		lines[i] = line
+	}
+
+	for _, line := range want {
+		line = strings.TrimSpace(strings.TrimRight(line, "\r"))
+		if line == "" {
+			continue
+		}
+		key := rdpKey(line)
+		if key == "" {
+			continue
+		}
+		if idx, ok := keyIndex[key]; ok {
+			lines[idx] = line
+		} else {
+			keyIndex[key] = len(lines)
+			lines = append(lines, line)
+		}
+	}
+
+	out := strings.Join(lines, "\n")
+	out = strings.TrimRight(out, "\n") + "\n"
+	return strings.ReplaceAll(out, "\n", "\r\n")
+}
+
 func (h *Handler) HandleDownload(w http.ResponseWriter, r *http.Request) {
 	id := identity.FromRequestCtx(r)
 	ctx := r.Context()
@@ -419,6 +470,17 @@ func (h *Handler) HandleDownload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	host = strings.Replace(host, "{{ preferred_username }}", id.UserName(), 1)
+
+	multimonLine := ""
+	if multimon := strings.TrimSpace(r.URL.Query().Get("multimon")); multimon != "" {
+		switch multimon {
+		case "0", "1":
+			multimonLine = "use multimon:i:" + multimon
+		default:
+			http.Error(w, `invalid query parameter "multimon": must be "0" or "1"`, http.StatusBadRequest)
+			return
+		}
+	}
 
 	// split the username into user and domain
 	var user = id.UserName()
@@ -497,14 +559,16 @@ func (h *Handler) HandleDownload(w http.ResponseWriter, r *http.Request) {
 	d.Settings.GatewayCredentialMethod = 1
 	d.Settings.GatewayUsageMethod = 1
 
-	// no rdp siging so return as-is
-	if h.rdpSigner == nil {
-		http.ServeContent(w, r, fn, time.Now(), strings.NewReader(d.String()))
-		return
+	rdpContent := d.String()
+	if multimonLine != "" {
+		rdpContent = upsertRdpLines(rdpContent, []string{multimonLine})
 	}
 
-	// get rdp content
-	rdpContent := d.String()
+	// no rdp signing so return as-is
+	if h.rdpSigner == nil {
+		http.ServeContent(w, r, fn, time.Now(), strings.NewReader(rdpContent))
+		return
+	}
 
 	// sign rdp content
 	signedContent, err := h.rdpSigner.Sign(rdpContent)

--- a/cmd/rdpgw/web/web_test.go
+++ b/cmd/rdpgw/web/web_test.go
@@ -182,6 +182,118 @@ func TestHandler_HandleDownload(t *testing.T) {
 
 }
 
+func TestHandler_HandleDownloadMultimon(t *testing.T) {
+	tests := []struct {
+		name         string
+		query        string
+		template     string
+		wantStatus   int
+		wantMultimon string
+	}{
+		{
+			name:         "enabled",
+			query:        "?multimon=1",
+			wantStatus:   http.StatusOK,
+			wantMultimon: "1",
+		},
+		{
+			name:         "appends without blank line",
+			query:        "?multimon=1",
+			template:     "full address:s:10.0.0.1:3389\r\n",
+			wantStatus:   http.StatusOK,
+			wantMultimon: "1",
+		},
+		{
+			name:         "disabled",
+			query:        "?multimon=0",
+			wantStatus:   http.StatusOK,
+			wantMultimon: "0",
+		},
+		{
+			name:         "overrides template",
+			query:        "?multimon=0",
+			template:     "use multimon:i:1\r\n",
+			wantStatus:   http.StatusOK,
+			wantMultimon: "0",
+		},
+		{
+			name:         "keeps template without query parameter",
+			template:     "use multimon:i:1\r\n",
+			wantStatus:   http.StatusOK,
+			wantMultimon: "1",
+		},
+		{
+			name:       "invalid",
+			query:      "?multimon=true",
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest("GET", "/connect"+tt.query, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rr := httptest.NewRecorder()
+			id := identity.NewUser()
+
+			id.SetUserName(testuser)
+			id.SetAuthenticated(true)
+
+			req = identity.AddToRequestCtx(id, req)
+
+			var templateFile string
+			if tt.template != "" {
+				f, err := os.CreateTemp("", "rdp")
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer os.Remove(f.Name())
+
+				if _, err := f.WriteString(tt.template); err != nil {
+					t.Fatal(err)
+				}
+				if err := f.Close(); err != nil {
+					t.Fatal(err)
+				}
+				templateFile = f.Name()
+			}
+
+			u, _ := url.Parse(gateway)
+			c := Config{
+				HostSelection:     "roundrobin",
+				Hosts:             hosts,
+				PAATokenGenerator: paaTokenMock,
+				GatewayAddress:    u,
+				TemplateFile:      templateFile,
+			}
+			h := c.NewHandler()
+
+			hh := http.HandlerFunc(h.HandleDownload)
+			hh.ServeHTTP(rr, req)
+
+			if status := rr.Code; status != tt.wantStatus {
+				t.Errorf("handler returned wrong status code: got %v want %v",
+					status, tt.wantStatus)
+			}
+
+			if tt.wantMultimon == "" {
+				return
+			}
+
+			data := rdpToMap(strings.Split(rr.Body.String(), rdp.CRLF))
+			if data["use multimon"] != tt.wantMultimon {
+				t.Errorf("use multimon key in rdp does not match: got %v want %v", data["use multimon"], tt.wantMultimon)
+			}
+			if strings.Contains(rr.Body.String(), rdp.CRLF+rdp.CRLF+"use multimon") {
+				t.Error("use multimon should not be preceded by a blank line")
+			}
+		})
+	}
+}
+
 func TestHandler_HandleSignedDownload(t *testing.T) {
 	req, err := http.NewRequest("GET", "/connect", nil)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add a `multimon` query parameter to the RDP download endpoint.
- Set the generated RDP `use multimon` value when `multimon=0` or `multimon=1` is provided.
- Document the `/connect?multimon=1` usage and add web handler coverage.

Fixes #176.

## Validation
- `go test -mod=mod ./cmd/rdpgw/web`
- `git diff --check`

## Notes
- `go test -mod=mod ./...` was attempted locally, but `cmd/auth` fails to build against the local PAM headers because `github.com/msteinert/pam/v2` cannot resolve `C.PAM_BAD_ITEM`, `C.PAM_CONV_AGAIN`, and `C.PAM_INCOMPLETE`.