### PR TITLE
Bind cached tunnel reuse to the original session identity

### DIFF
--- a/cmd/rdpgw/protocol/gateway.go
+++ b/cmd/rdpgw/protocol/gateway.go
@@ -75,6 +75,11 @@ func (g *Gateway) HandleGatewayProtocol(w http.ResponseWriter, r *http.Request) 
 		}
 	} else {
 		t = x.(*Tunnel)
+		if !tunnelOwnerMatches(t, id) {
+			log.Printf("rejecting reuse of Rdg-Connection-Id %q from a different identity", connId)
+			http.Error(w, "Tunnel is owned by a different session", http.StatusUnauthorized)
+			return
+		}
 	}
 	ctx = context.WithValue(ctx, CtxTunnel, t)
 
@@ -104,6 +109,25 @@ func (g *Gateway) HandleGatewayProtocol(w http.ResponseWriter, r *http.Request) 
 	} else if r.Method == MethodRDGIN {
 		g.handleLegacyProtocol(w, r.WithContext(ctx), t)
 	}
+}
+
+// tunnelOwnerMatches reports whether the cached tunnel was opened by the same
+// identity making the current request. The Rdg-Connection-Id is a client-
+// chosen header that pairs the two halves of a session; without this check
+// any caller who learns or guesses one can attach to another user's tunnel.
+func tunnelOwnerMatches(t *Tunnel, id identity.Identity) bool {
+	if t == nil || t.User == nil || id == nil {
+		return false
+	}
+	if t.User.UserName() == "" || t.User.UserName() != id.UserName() {
+		return false
+	}
+	cachedIp, _ := t.User.GetAttribute(identity.AttrClientIp).(string)
+	reqIp, _ := id.GetAttribute(identity.AttrClientIp).(string)
+	if cachedIp == "" {
+		return false
+	}
+	return cachedIp == reqIp
 }
 
 // headerHasToken reports whether the HTTP header named by name contains

--- a/cmd/rdpgw/protocol/gateway_test.go
+++ b/cmd/rdpgw/protocol/gateway_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/bolkedebruin/rdpgw/cmd/rdpgw/identity"
+	"github.com/patrickmn/go-cache"
 )
 
 func TestHeaderHasToken(t *testing.T) {
@@ -142,5 +143,65 @@ func TestHandleGatewayProtocolRouting(t *testing.T) {
 				t.Errorf("status line = %q, want %q", line, tc.wantStatusLine)
 			}
 		})
+	}
+}
+
+// TestTunnelOwnershipEnforced asserts that an Rdg-Connection-Id which already
+// has a cached tunnel cannot be reused by a different identity. The connection
+// id travels in plain HTTP headers, so a client that learns or guesses one
+// must not be able to attach to the original tunnel — the cache is for
+// matching the two halves of the same client's session, not for authorizing
+// access.
+func TestTunnelOwnershipEnforced(t *testing.T) {
+	connId := "shared-connid-ownership"
+
+	aliceID := identity.NewUser()
+	aliceID.SetUserName("alice")
+	aliceID.SetAttribute(identity.AttrRemoteAddr, "10.1.1.1:1234")
+	aliceID.SetAttribute(identity.AttrClientIp, "10.1.1.1")
+	c.Set(connId, &Tunnel{
+		RDGId:      connId,
+		RemoteAddr: "10.1.1.1:1234",
+		User:       aliceID,
+	}, cache.DefaultExpiration)
+	defer c.Delete(connId)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bob := identity.NewUser()
+		bob.SetUserName("bob")
+		bob.SetAttribute(identity.AttrRemoteAddr, "10.2.2.2:5678")
+		bob.SetAttribute(identity.AttrClientIp, "10.2.2.2")
+		r = identity.AddToRequestCtx(bob, r)
+		(&Gateway{}).HandleGatewayProtocol(w, r)
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	addr := strings.TrimPrefix(srv.URL, "http://")
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	if err := conn.SetDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+
+	req := "RDG_OUT_DATA /remoteDesktopGateway/ HTTP/1.1\r\n" +
+		"Host: " + addr + "\r\n" +
+		"Rdg-Connection-Id: " + connId + "\r\n" +
+		"\r\n"
+	if _, err := conn.Write([]byte(req)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	line, err := bufio.NewReader(conn).ReadString('\n')
+	if err != nil {
+		t.Fatalf("read status line: %v", err)
+	}
+	line = strings.TrimRight(line, "\r\n")
+
+	if strings.HasPrefix(line, "HTTP/1.1 2") {
+		t.Fatalf("a different identity attached to a cached tunnel via Rdg-Connection-Id (status %q); the header was treated as authorization", line)
 	}
 }


### PR DESCRIPTION
## Summary

`HandleGatewayProtocol` caches a `*Tunnel` keyed on the client-supplied `Rdg-Connection-Id` header so the two halves of a session (RDG_OUT_DATA and RDG_IN_DATA) can rendezvous on a single record. The cache-hit path previously reused the tunnel without checking who was making the follow-up request — so a follow-up from a different identity would attach to the original tunnel.

This PR ties cache reuse to the identity that originally opened the tunnel:

- New `tunnelOwnerMatches(t, id)` helper — compares the cached tunnel's `User.UserName()` and `AttrClientIp` against the request identity.
- In `HandleGatewayProtocol`, on a cache hit the handler now runs the check before reusing the tunnel; on mismatch it returns `401 Tunnel is owned by a different session`.
- Conservative defaults: nil tunnel/user/identity, empty username, or a missing client-IP attribute all fail closed.

The legitimate case (the same client returns to attach its second half-channel to its own first half) is unchanged.

## Test plan

- [x] New `TestTunnelOwnershipEnforced` puts a tunnel owned by alice in the cache, then sends `RDG_OUT_DATA` with the same `Rdg-Connection-Id` from a different identity. Asserts the response is not `2xx`.
- [x] Existing `TestHandleGatewayProtocolRouting` (cache-miss → fresh tunnel per request) still passes.
- [x] `go vet ./...` and `go test ./...` green on the full tree.
